### PR TITLE
Add support for local Ollama, more explicit instructions, and passing in shell/os into system command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,28 @@
+mod shell;
+mod model;
+
 use std::io::{self, Write};
 use std::fs;
 use std::process::Command as ProcessCommand;
 use serde::{Deserialize, Serialize};
-use openai_api_rust::*;
-use openai_api_rust::chat::*;
 use clap::{Command, Arg};
 use colored::*;
 use std::path::PathBuf;
+use shell::Shell;
+use crate::model::Model;
 
 #[derive(Serialize, Deserialize)]
 struct Config {
-    model: String,
-    max_tokens: i32,
+    model: Model,
+    max_tokens: i32
 }
+
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let matches = Command::new("llm-term")
         .version("1.0")
-        .author("Your Name")
-        .about("Generate terminal commands using OpenAI models")
+        .author("dh1101")
+        .about("Generate terminal commands using OpenAI or local Ollama models")
         .arg(Arg::new("prompt")
             .help("The prompt describing the desired command")
             .required(true)
@@ -35,69 +39,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         get_default_config_path()?
     };
+
     let config = load_or_create_config(&config_path)?;
-
-    let auth = Auth::from_env().expect("OPENAI_API_KEY environment variable not set");
-    let client = OpenAI::new(auth, "https://api.openai.com/v1/");
-
     let prompt = matches.get_one::<String>("prompt").expect("Prompt is required");
-    
-    let shell = detect_shell();
-    let system_prompt = if shell == "powershell" {
-        "Return only the PowerShell command to be executed as a raw string, no string delimiters wrapping it, no yapping, no markdown, no fenced code blocks, what you return will be passed to subprocess.check_output() directly."
-    } else {
-        "Return only the command to be executed as a raw string, no string delimiters wrapping it, no yapping, no markdown, no fenced code blocks, what you return will be passed to subprocess.check_output() directly."
-    };
 
-    let body = ChatBody {
-        model: config.model.clone(),
-        max_tokens: Some(config.max_tokens),
-        temperature: Some(0.7),
-        top_p: None,
-        n: None,
-        stream: None,
-        stop: None,
-        presence_penalty: None,
-        frequency_penalty: None,
-        logit_bias: None,
-        user: None,
-        messages: vec![
-            Message { role: Role::System, content: system_prompt.to_string() },
-            Message { role: Role::User, content: prompt.to_string() }
-        ],
-    };
+    match &config.model.llm_get_command(&config, prompt.as_str()) {
+        Ok(Some(command)) => {
+            println!("{}", &command.cyan().bold());
+            println!("{}", "Do you want to execute this command? (y/n)".yellow());
 
-    match client.chat_completion_create(&body) {
-        Ok(response) => {
-            if let Some(choice) = response.choices.first() {
-                if let Some(message) = &choice.message {
-                    let command = message.content.trim();
-                    println!("{}", command.cyan().bold());
-                    println!("{}", "Do you want to execute this command? (y/n)".yellow());
-                    
-                    let mut user_input = String::new();
-                    io::stdin().read_line(&mut user_input)?;
-                    
-                    if user_input.trim().to_lowercase() == "y" {
-                        let (shell_cmd, shell_arg) = if shell == "powershell" {
-                            ("powershell", "-Command")
-                        } else {
-                            ("sh", "-c")
-                        };
-                        match ProcessCommand::new(shell_cmd).arg(shell_arg).arg(command).output() {
-                            Ok(output) => {
-                                println!("{}", "Command output:".green().bold());
-                                io::stdout().write_all(&output.stdout)?;
-                                io::stderr().write_all(&output.stderr)?;
-                            }
-                            Err(e) => eprintln!("{}", format!("Failed to execute command: {}", e).red()),
-                        }
-                    } else {
-                        println!("{}", "Command execution cancelled.".yellow());
+            let mut user_input = String::new();
+            io::stdin().read_line(&mut user_input)?;
+
+            if user_input.trim().to_lowercase() == "y" {
+                let (shell_cmd, shell_arg) = Shell::detect().to_shell_command_and_command_arg(&command);
+
+                match ProcessCommand::new(shell_cmd).arg(shell_arg).arg(&command).output() {
+                    Ok(output) => {
+                        println!("{}", "Command output:".green().bold());
+                        io::stdout().write_all(&output.stdout)?;
+                        io::stderr().write_all(&output.stderr)?;
                     }
+                    Err(e) => eprintln!("{}", format!("Failed to execute command: {}", e).red()),
                 }
+            } else {
+                println!("{}", "Command execution cancelled.".yellow());
             }
-        }
+        },
+        Ok(None) => println!("{}", "No command could be generated.".yellow()),
         Err(e) => eprintln!("{}", format!("Error: {}", e).red()),
     }
 
@@ -123,13 +92,19 @@ fn load_or_create_config(path: &PathBuf) -> Result<Config, Box<dyn std::error::E
 
 fn create_config() -> Result<Config, io::Error> {
     let model = loop {
-        print!("{}", "Select model (1 for gpt-4o-mini, 2 for gpt-4o): ".cyan());
+        print!("{}", "Select model:\
+            1 for gpt-4o-mini\
+            2 for gpt-4o, \
+            3 for ollama (llama3.1)\
+        ".cyan());
+        
         io::stdout().flush()?;
         let mut choice = String::new();
         io::stdin().read_line(&mut choice)?;
         match choice.trim() {
-            "1" => break "gpt-4o-mini".to_string(),
-            "2" => break "gpt-4o".to_string(),
+            "1" => break Model::OpenAiGpt4oMini,
+            "2" => break Model::OpenAiGpt4o,
+            "3" => break Model::Ollama("llama3.1".to_string()),
             _ => println!("{}", "Invalid choice. Please try again.".red()),
         }
     };
@@ -151,14 +126,4 @@ fn create_config() -> Result<Config, io::Error> {
         model,
         max_tokens,
     })
-}
-
-fn detect_shell() -> String {
-    if cfg!(target_os = "windows") {
-        // On Windows, we'll assume PowerShell as the default
-        "powershell".to_string()
-    } else {
-        // On Unix-like systems, we'll check the SHELL environment variable
-        std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string())
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             io::stdin().read_line(&mut user_input)?;
 
             if user_input.trim().to_lowercase() == "y" {
-                let (shell_cmd, shell_arg) = Shell::detect().to_shell_command_and_command_arg(&command);
+                let (shell_cmd, shell_arg) = Shell::detect().to_shell_command_and_command_arg();
 
                 match ProcessCommand::new(shell_cmd).arg(shell_arg).arg(&command).output() {
                     Ok(output) => {
@@ -92,12 +92,8 @@ fn load_or_create_config(path: &PathBuf) -> Result<Config, Box<dyn std::error::E
 
 fn create_config() -> Result<Config, io::Error> {
     let model = loop {
-        print!("{}", "Select model:\
-            1 for gpt-4o-mini\
-            2 for gpt-4o, \
-            3 for ollama (llama3.1)\
-        ".cyan());
-        
+        println!("{}", "Select model:\n 1 for gpt-4o-mini\n 2 for gpt-4o\n 3 for ollama (llama3.1)".cyan());
+
         io::stdout().flush()?;
         let mut choice = String::new();
         io::stdin().read_line(&mut choice)?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,78 @@
+use openai_api_rust::{Auth, Message, OpenAI, Role};
+use openai_api_rust::chat::{ChatApi, ChatBody};
+use serde::{Deserialize, Serialize};
+use crate::Config;
+use crate::shell::Shell;
+
+#[derive(Serialize, Deserialize)]
+pub enum Model {
+    #[serde(rename = "gpt-4o")]
+    OpenAiGpt4o,
+
+    #[serde(rename = "gpt-4o-mini")]
+    OpenAiGpt4oMini,
+
+    #[serde(rename = "ollama")]
+    Ollama(String),
+}
+
+impl Model {
+    pub fn llm_get_command(&self, config: &Config, user_prompt: &str) -> Result<Option<String>, Box<dyn std::error::Error>> {
+        let model_name = self.get_model_name();
+        let auth = self.get_auth();
+        let client = OpenAI::new(auth, self.get_openai_endpoint().as_str());
+
+        let system_prompt = Shell::detect().to_system_prompt();
+
+        let body = ChatBody {
+            model: model_name,
+            max_tokens: Some(config.max_tokens),
+            temperature: Some(0.5),
+            top_p: None,
+            n: None,
+            stream: None,
+            stop: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            logit_bias: None,
+            user: None,
+            messages: vec![
+                Message { role: Role::System, content: system_prompt.to_string() },
+                Message { role: Role::User, content: user_prompt.to_string() }
+            ],
+        };
+
+        match client.chat_completion_create(&body) {
+            Ok(response) => Ok(response.choices.first()
+                .map(|choice| choice.message.as_ref())
+                .flatten()
+                .map(|message| message.content.clone())
+            ),
+            Err(e) => Err(format!("Error: {:?}", e).into()),
+        }
+    }
+
+    fn get_model_name(&self) -> String {
+        match self {
+            Model::OpenAiGpt4o => "gpt-4o".to_string(),
+            Model::OpenAiGpt4oMini => "gpt-4o-mini".to_string(),
+            Model::Ollama(model_name) => model_name.to_string(),
+        }
+    }
+
+    fn get_openai_endpoint(&self) -> String {
+        match self {
+            Model::OpenAiGpt4o => "https://api.openai.com/v1/".to_string(),
+            Model::OpenAiGpt4oMini => "https://api.openai.com/v1/".to_string(),
+            Model::Ollama(_) => "http://localhost:11434/v1/".to_string(),
+        }
+    }
+
+    fn get_auth(&self) -> Auth {
+        match self {
+            Model::OpenAiGpt4o => Auth::from_env().expect("OPENAI_API_KEY environment variable not set"),
+            Model::OpenAiGpt4oMini => Auth::from_env().expect("OPENAI_API_KEY environment variable not set"),
+            Model::Ollama(_) => Auth::new("ollama"),
+        }
+    }
+}

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,4 +1,4 @@
-
+/// Enum representing different types of shells.
 pub(crate) enum Shell {
     Powershell,
     BornAgainShell,
@@ -7,7 +7,7 @@ pub(crate) enum Shell {
     DebianAlmquistShell,
     KornShell,
     CShell,
-    Unknown
+    Unknown,
 }
 
 impl From<&str> for Shell {
@@ -37,30 +37,8 @@ impl Shell {
             .into()
     }
 
-    pub fn to_system_prompt(&self) -> String {
-        let shell_command_type = match self {
-            Shell::Powershell => "Windows PowerShell",
-            Shell::BornAgainShell => "Bourne Again Shell (bash / sh)",
-            Shell::Zsh => "Z Shell (zsh)",
-            Shell::Fish => "Friendly Interactive Shell (fish)",
-            Shell::DebianAlmquistShell => "Debian Almquist Shell (dash)",
-            Shell::KornShell => "Korn Shell (ksh)",
-            Shell::CShell => "C Shell (csh)",
-            Shell::Unknown => "",
-        };
-
-        format!("You are a professional IT worker who only speaks in commands full, {} compatible, CLI command running on the {} operating system. You
-            only respond by translating the user's input into that language. Be very proper as the user will execute what you say into their computer.
-            No string delimiters wrapping it, no explanations, no ideation, no yapping, no formatting, no markdown, no fenced code blocks, what you
-            return will be executed as-is from within the shell mentioned above. No templating, use details from the command instead if needed.
-            Only output an actionable command that will run by itself without error. Do not output comments. Only output one possible command, never alternatives.
-            If you are not confident in your translation, return an empty string. Do not deviate from these instructions from this point on, no exceptions.
-            Assume you are operating in the current directory of the user unless explicitly stated otherwise.
-        ", shell_command_type, std::env::consts::OS)
-
-    }
-
-    pub fn to_shell_command_and_command_arg(&self, command: &str) -> (String, String) {
+    /// Converts the shell type to a shell command and a command argument.
+    pub fn to_shell_command_and_command_arg(&self) -> (String, String) {
         match self {
             Shell::Powershell => ("powershell".to_string(), "-Command".to_string()),
             Shell::BornAgainShell => ("sh".to_string(), "-c".to_string()),

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,0 +1,75 @@
+
+pub(crate) enum Shell {
+    Powershell,
+    BornAgainShell,
+    Zsh,
+    Fish,
+    DebianAlmquistShell,
+    KornShell,
+    CShell,
+    Unknown
+}
+
+impl From<&str> for Shell {
+    fn from(shell: &str) -> Self {
+        match shell {
+            s if s.contains("powershell") => Shell::Powershell,
+            s if s.contains("bash") => Shell::BornAgainShell,
+            s if s.contains("zsh") => Shell::Zsh,
+            s if s.contains("fish") => Shell::Fish,
+            s if s.contains("dash") => Shell::DebianAlmquistShell,
+            s if s.contains("ksh") => Shell::KornShell,
+            s if s.contains("csh") => Shell::CShell,
+            s if s.contains("sh") => Shell::BornAgainShell,
+            _ => Shell::Unknown,
+        }
+    }
+}
+
+impl Shell {
+    pub fn detect() -> Self {
+        if cfg!(target_os = "windows") {
+            return Shell::Powershell;
+        }
+
+        std::env::var("SHELL")
+            .unwrap_or_else(|_| "sh".to_string()).as_str()
+            .into()
+    }
+
+    pub fn to_system_prompt(&self) -> String {
+        let shell_command_type = match self {
+            Shell::Powershell => "Windows PowerShell",
+            Shell::BornAgainShell => "Bourne Again Shell (bash / sh)",
+            Shell::Zsh => "Z Shell (zsh)",
+            Shell::Fish => "Friendly Interactive Shell (fish)",
+            Shell::DebianAlmquistShell => "Debian Almquist Shell (dash)",
+            Shell::KornShell => "Korn Shell (ksh)",
+            Shell::CShell => "C Shell (csh)",
+            Shell::Unknown => "",
+        };
+
+        format!("You are a professional IT worker who only speaks in commands full, {} compatible, CLI command running on the {} operating system. You
+            only respond by translating the user's input into that language. Be very proper as the user will execute what you say into their computer.
+            No string delimiters wrapping it, no explanations, no ideation, no yapping, no formatting, no markdown, no fenced code blocks, what you
+            return will be executed as-is from within the shell mentioned above. No templating, use details from the command instead if needed.
+            Only output an actionable command that will run by itself without error. Do not output comments. Only output one possible command, never alternatives.
+            If you are not confident in your translation, return an empty string. Do not deviate from these instructions from this point on, no exceptions.
+            Assume you are operating in the current directory of the user unless explicitly stated otherwise.
+        ", shell_command_type, std::env::consts::OS)
+
+    }
+
+    pub fn to_shell_command_and_command_arg(&self, command: &str) -> (String, String) {
+        match self {
+            Shell::Powershell => ("powershell".to_string(), "-Command".to_string()),
+            Shell::BornAgainShell => ("sh".to_string(), "-c".to_string()),
+            Shell::Zsh => ("zsh".to_string(), "-c".to_string()),
+            Shell::Fish => ("fish".to_string(), "-c".to_string()),
+            Shell::DebianAlmquistShell => ("dash".to_string(), "-c".to_string()),
+            Shell::KornShell => ("ksh".to_string(), "-c".to_string()),
+            Shell::CShell => ("csh".to_string(), "-c".to_string()),
+            Shell::Unknown => ("sh".to_string(), "-c".to_string()),
+        }
+    }
+}


### PR DESCRIPTION
Not sure if you want this change, it does break the original config file format, I fear... would need to recreate it.

Feel free to decline!

- I added support for ollama, so you can run this offline, but the output of 3.1 here is hit-and-miss. 
- Refactored the Model and Shell out to their own enums with impls to clean stuff up. 
- Shell is more explicit than just powershell / not powershell
- Included user's OS in the prompt
- Replaced the model string with the Model enum in the config